### PR TITLE
Changed DomainGlob for LimitRule in crawler

### DIFF
--- a/core/crawler.go
+++ b/core/crawler.go
@@ -190,7 +190,7 @@ func NewCrawler(site *url.URL, cmd *cobra.Command) *Crawler {
 
     // Set Limit Rule
     err := c.Limit(&colly.LimitRule{
-        DomainGlob:  domain,
+        DomainGlob:  "*",
         Parallelism: concurrent,
         Delay:       time.Duration(delay) * time.Second,
         RandomDelay: time.Duration(randomDelay) * time.Second,


### PR DESCRIPTION
I needed crawl delays, but it did not seem to be working. Based on the colly docs found [here](https://godoc.org/github.com/gocolly/colly#LimitRule) it seems the delay is only implemented when it matches DomainGlob. I am assuming the delay is meant to be applied for all links crawled.