### PR TITLE
removing lower case conversion of paths and parameters

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -137,7 +137,7 @@ func DecodeChars(s string) string {
 		`\u002f`, "/",
 		`\u0026`, "&",
 	)
-	s = replacer.Replace(strings.ToLower(s))
+	s = replacer.Replace(s)
 	return s
 }
 


### PR DESCRIPTION
Gospider was converting case-sensitive paths and parameters to lowercase which results in lots of valid case-sensitive paths and parameters being 404 not found.
For example a path found in HTML or JavaScript source:
/SearchLive.php?Param=1
converts to:
/searchlive.php?param=1