### PR TITLE
Update crawler.go

### DIFF
--- a/core/crawler.go
+++ b/core/crawler.go
@@ -251,7 +251,7 @@ func NewCrawler(site *url.URL, cmd *cobra.Command) *Crawler {
 	}
 
 	// GoSpider default disallowed regex
-	disallowedRegex := `(?i)\.(png|apng|bmp|gif|ico|cur|jpg|jpeg|jfif|pjp|pjpeg|svg|tif|tiff|webp|xbm|3gp|aac|flac|mpg|mpeg|mp3|mp4|m4a|m4v|m4p|oga|ogg|ogv|mov|wav|webm|eot|woff|woff2|ttf|otf|css)(?:\?|#|$)`
+	disallowedRegex := `(?i)\.(png|apng|bmp|gif|ico|cur|jpg|jpeg|jfif|pjp|pjpeg|svg|tif|tiff|webp|xbm|3gp|aac|flac|mpg|mpeg|mp3|mp4|m4a|m4v|m4p|oga|ogg|ogv|mov|wav|webm|eot|woff|woff2|ttf|otf|css)(?:\?|#|$)|(?i)(js/image|text/js|text/html|text/xml|js/js/js|text/javascript|text/plain|application/(x-.*|json|zip|xml|msword|pdf))`
 	c.DisallowedURLFilters = append(c.DisallowedURLFilters, regexp.MustCompile(disallowedRegex))
 
 	// Set optional blacklist url regex


### PR DESCRIPTION
when crawling some sites output is like

```
js/image
text/js
text/html
text/xml|js
js/js/js/
text/javascript
text/plain
e.t.c
```

the reason is jslinkfinder module.
easy way fix this add to blacklist which is default true

or add this mime type on blacklists and don't add to in output URLs
https://github.com/fuzzdb-project/fuzzdb/blob/master/attack/mimetypes/MimeTypes.txt