### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Enjoying this tool? Support it's development and take your game to the next leve
 ## Installation
 
 ```
-GO111MODULE=on go get -u github.com/jaeles-project/gospider
+GO111MODULE=on go install github.com/jaeles-project/gospider@latest
 ```
 
 ## Features


### PR DESCRIPTION
Installing executables with "go get" in module mode is deprecated.
"go install pkg@version" should be used instead.
For more information, see https://golang.org/doc/go-get-install-deprecation