### PR TITLE
remove go111module=on

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## Installation
 
 ```
-GO111MODULE=on go install github.com/jaeles-project/gospider@latest
+go install github.com/jaeles-project/gospider@latest
 ```
 
 ## Features


### PR DESCRIPTION
Installing binaries with GO111MODULE=on go get is deprecated and is enabled by default 